### PR TITLE
Rewrite README as a polished, user-friendly guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,250 +1,308 @@
-# GIQPy: Generate Inputs for QM/MM systems
+<div align="center">
 
-The workflow is split into two scripts:
+# GIQPy
 
-1. **`giqpy.py`** — turns a trajectory (or single frame) into **.xyz** files: one QM-region file
-   and one MM point-charge file per monomer and for the aggregate. 
-2. **`xyz-to-gaussian.py`** — converts those `.xyz` files into `Gaussian` **.com** input files
-   (per monomer, the aggregate/dimer, or an EET-analysis dimer) with a given set of keywords.
+**G**enerate **I**nputs for **Q**M/MM systems — in **Py**thon
 
-`run-giqpy.sh` chains both stages together.
+Turn a molecular-dynamics trajectory into ready-to-run **Gaussian** `.com` inputs
+(or **TeraChem**-friendly `.xyz` files) for monomers, dimers, and aggregates —
+with automatic QM/MM solvent partitioning.
 
-## Overview
+![Python](https://img.shields.io/badge/python-3.8%2B-blue)
+![NumPy](https://img.shields.io/badge/numpy-required-013243?logo=numpy&logoColor=white)
+![Status](https://img.shields.io/badge/status-active-success)
+![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macOS-lightgrey)
 
-- **Input:**
-  - **Single frame**: A single XYZ file containing the coordinates of the entire system (core monomers + solvent).
-  - **Multi-frame**: A multi-frame XYZ trajectory, where each frame is in standard XYZ format.
-- **Code capabilities:**
-  - **Simple usage** : generate a .com file for a single frame system (.xyz) with a given set of keywords.
-  - **Configuring aggregates**:
-    - We define, no_of_aggregates: 1 = monomer, 2 = dimer, >=2 = aggregate.
-    - **`aggregate files`**: all the solute molecules will be present in the .com file and the .xyz file.
-    - **`isolated monomer files`**: user has the following options
-      - other monomer can be skipped
-      - other monomer can be included with zero charges in the MM region
-      - other monomer can be included with its specific MM charges in the MM region
-  - **Configuring solvent region**: (given a single-frame or multi-frame XYZ file with solute in a solvent)
-    - ***`QM solvent`***: user can pick out a localized QM solvent region by specifying a distance cutoff around each atom of the solute. In case of multiple solute molecules, each solvent molecule within the cutoff is assigned to the **single nearest** monomer (by minimum atom-atom distance). This guarantees the QM solvent region is unique to each solute molecule — no solvent atom is ever shared between two monomers.
-    - ***`MM solvent`***: user can provide a file with the coordinates of the solvent region, or the code can auto-detect the non-QM solvent and assign charges from the `system_info` JSON.
-    - The user can make combinations: no solvent, QM solvent only, MM solvent only, or both QM and MM solvent.
-    - This will be executed for each frame in case of a multi-frame trajectory XYZ file.
+</div>
 
-- **Output:**
-  - **.com files**:
-    - generated for each monomer and dimer (if applicable) with the specified keywords.
-    - genearated for **EET Analysis** calculations with proper formatting. (only for dimers)
-  - **.xyz files**: a separate .xyz file for QM region and its corresponding MM solvent region.
+---
 
+## Table of contents
 
+- [Why GIQPy?](#why-giqpy)
+- [How it works](#how-it-works)
+- [Installation](#installation)
+- [Quick start](#quick-start)
+- [Input files](#input-files)
+- [Output files](#output-files)
+- [Command-line reference](#command-line-reference)
+- [Notes & tips](#notes--tips)
+- [Acknowledgements](#acknowledgements)
 
-## Arguments
+---
 
-### `giqpy.py` (XYZ generation)
-`--traj` *(Required)*:
-  - ***Number of inputs:*** 1 file
-  - Multi-frame trajectory XYZ file. For a single-frame input use `--num-frames 1`.
----
-`--num-frames` *(Optional)*:
-  - ***Number of inputs:*** 1 integer
-  - Number of frames to process (default: all).
----
-`--num-monomers` *(Required)*:
-  - ***Number of inputs:*** 1 integer
-  - Number of core monomer units.
----
-`--system-info` *(Required)*:
-  - ***Number of inputs:*** 1 file
-  - JSON defining monomer and solvent metadata (format described below)
----
-`--qm-radius` *(Optional)*:
-  - ***Number of inputs:*** 1 float
-  - Radius in Å for selecting explicit QM solvent shell around core atoms
----
-`--mm-monomer` *(Optional)*:
-  - ***Number of inputs:*** 0 or N files
-  - Include MM embedding charges from other monomers
-  - `0` = all atoms are assigned zero charges
-  -  List charge files with “charge x y z” per line for `N` monomers if `--num-monomers N`
-  - Omit flag for no MM monomer charges
----
-`--mm-solvent` *(Optional)*:
-  - ***Number of inputs:*** 0 or 1 file
-  - Include MM solvent embedding
-  - flag alone to auto-detect non-QM solvent and assign charges from `system_info`
-  - or provide XYZ-like file path of charges
-  - omit flag for no MM solvent
----
-- `--log-file`: (Optional)
-  - ***Number of inputs:*** 0 or 1 string
-  - Name for detailed log file (default `giqpy-run.log`)
+## Why GIQPy?
 
-### `xyz-to-gaussian.py` (Gaussian .com generation)
-`--input-dir` *(Optional)*:
-  - ***Number of inputs:*** 1 directory
-  - Directory holding the XYZ files, or a parent containing numbered per-frame subdirectories (default: current directory).
----
-`--num-monomers` *(Required)*:
-  - ***Number of inputs:*** 1 integer
-  - Number of core monomer units (must match the `giqpy.py` run).
----
-`--system-info` *(Required)*:
-  - ***Number of inputs:*** 1 file
-  - Same JSON used by `giqpy.py` (provides charge / spin / names).
----
-`--gauss-keywords` *(Required)*:
-  - ***Number of inputs:*** 1 file
-  - Plain-text file of Gaussian route section keywords (one per line)
----
-`--com-files` *(Optional)*:
-  - ***Number of inputs:*** 1 string : `monomer`, `dimer`, `both` (default `both`)
-  - Which `.com` files to generate.
----
-`--eetg` *(Optional)*:
-  - ***Number of inputs:*** 0 (flag)
-  - Generate only EETG `.com` for dimers (requires `--num-monomers 2`)
----
-- `--tag`: (Optional)
-  - ***Number of inputs:*** 0 or 1 string
-  - Custom tag appended to generated .com filenames
----
-- `--log-file`: (Optional)
-  - ***Number of inputs:*** 0 or 1 string
-  - Name for detailed log file (default `xyz-to-gaussian.log`)
+Setting up excited-state QM/MM calculations for solvated chromophore aggregates is fiddly:
+you have to slice the trajectory into monomers, decide which solvent molecules are quantum
+vs. point-charge, keep charges and spin multiplicities straight, and format everything for
+your QM package. GIQPy automates all of it.
 
-## Quick Start
+**Highlights**
+
+- 🧩 **Monomers, dimers & aggregates** — generate isolated-monomer, full-aggregate, and
+  EET-analysis (EETG) inputs from the same trajectory.
+- 💧 **QM/MM solvent partitioning** — pick a QM solvent shell by radius; treat the rest as MM point charges (or auto-detect them).
+- 🎯 **Guaranteed-unique QM solvent** *(see callout below)*.
+- 🔌 **Embedding options** — embed the *other* monomers as zero charges or as explicit MM charges.
+- 🎬 **Trajectory-aware** — process one frame or thousands; each frame lands in its own folder.
+- 🏷️ **You name things** — output files are named from labels you choose in the JSON.
+- 🧪 **Two packages, one pipeline** — geometry generation is decoupled from Gaussian formatting,
+  so the `.xyz` files work with TeraChem too.
+
+> [!IMPORTANT]
+> **Unique QM solvent per monomer.** When several solute molecules share a solvent shell,
+> each solvent molecule within the cutoff is assigned to the **single nearest** monomer
+> (by minimum atom–atom distance). No solvent atom is ever shared between two monomers'
+> QM regions, while the aggregate QM region is exactly the union of all selected solvent molecules.
+
+---
+
+## How it works
+
+GIQPy is a two-stage pipeline. Stage 1 is geometry; stage 2 is QM-package formatting.
+
+```mermaid
+flowchart LR
+    T[Trajectory XYZ]:::in --> G[giqpy.py]
+    J[system_info.json]:::in --> G
+    G --> X["QM-region .xyz<br/>+ MM-charge .xyz<br/>(per frame)"]:::mid
+    X --> H[xyz-to-gaussian.py]
+    K[keywords.txt]:::in --> H
+    J --> H
+    H --> C[Gaussian .com files]:::out
+    X -. also usable by .-> TC[TeraChem]:::out
+
+    classDef in fill:#eef,stroke:#88a;
+    classDef mid fill:#efe,stroke:#8a8;
+    classDef out fill:#fee,stroke:#a88;
+```
+
+| Stage | Script | In → Out |
+|------:|--------|----------|
+| **1** | `giqpy.py` | trajectory `.xyz` + `system_info.json` → per-frame QM-region & MM-charge `.xyz` files |
+| **2** | `xyz-to-gaussian.py` | those `.xyz` files + `keywords.txt` → Gaussian `.com` inputs |
+
+`run-giqpy.sh` is a thin wrapper that runs both stages back-to-back.
+
+---
+
+## Installation
+
+GIQPy is a set of standalone scripts — just clone and run.
 
 ```bash
-# 1) generate QM-region + MM-charge XYZ files
-python giqpy.py --traj my_traj.xyz --num-frames 1 --num-monomers 2 \
-    --system-info examples/cv_dimer_water.json --qm-radius 5 --mm-solvent
-
-# 2) build Gaussian .com files from those XYZ files
-python xyz-to-gaussian.py --input-dir . --num-monomers 2 \
-    --system-info examples/cv_dimer_water.json \
-    --gauss-keywords examples/keywords.txt --com-files monomer
+git clone https://github.com/sayan919/GIQPy.git
+cd GIQPy
+pip install numpy        # the only third-party dependency
 ```
+
+**Requirements:** Python ≥ 3.8 and NumPy. Everything else is from the standard library.
+
+---
+
+## Quick start
+
+```bash
+# Stage 1 — generate QM-region + MM-charge XYZ files
+python giqpy.py \
+    --traj my_traj.xyz --num-frames 1 --num-monomers 2 \
+    --system-info examples/cv_dimer_water.json \
+    --qm-radius 5 --mm-solvent
+
+# Stage 2 — build Gaussian .com files from those XYZ files
+python xyz-to-gaussian.py \
+    --input-dir . --num-monomers 2 \
+    --system-info examples/cv_dimer_water.json \
+    --gauss-keywords examples/keywords.txt --com-files both
+```
+
+> 💡 **Single frame?** Pass `--num-frames 1`. **Whole trajectory?** Omit `--num-frames`.
 
 ---
 
 ## Input files
-### `keywords.txt`
-- The file must be a **plain text** file with one entry per line.
-  Example: [keywords.txt](./examples/keywords.txt)
-  ```text
-  #p CAM-B3LYP/6-31G*                 ! Functional/basis set
-  # TDA(Nstates=6)                    ! Excited state calculations
-  # Density(Transition=1)             ! S0->S1 transition density
-  # Integral(grid=fine)               ! Grid for two-electron integrals
-  # SCF(conver=10)                    ! SCF convergence
-  # NoSymm                            ! No symmetry keyword for dimers
-  # EmpiricalDispersion=GD3           ! Dispersion interaction
-  # IOp(9/40=4)                       ! Print eigenvector components threshold
-  ```
 
-### `system_info.json` 
+### 1. Trajectory (`--traj`)
 
-- The file must be a **JSON array** with one entry per monomer followed by **one**
-entry describing the solvent. 
+A standard multi-frame XYZ file (each frame = atom-count line, comment line, then `element x y z` rows).
+Which atoms belong to which monomer/solvent is decided by the `index` field in `system_info.json` (below).
 
-  Example: [cv_dimer_water.json](./examples/cv_dimer_water.json)
-  ```jsonc
-  [
-    {
-      "system"      : "m1",            // label used to NAME this system's output files
-      "name"        : "cv",            // descriptive name shown in titles/comments
-      "mol_formula" : "C16H12N3O1",
-      "nAtoms"      : 32,
-      "index"       : "0-31",          // 0-based atom indices for this monomer in the trajectory
-      "charge"      : 1,
-      "spin_mult"   : 1
-    },
-    {
-      "system"      : "m2",
-      "name"        : "cv",
-      "mol_formula" : "C16H12N3O1",
-      "nAtoms"      : 32,
-      "index"       : "32-63",
-      "charge"      : 1,
-      "spin_mult"   : 1
-    },
-    {
-      "system"      : "solvent",
-      "name"        : "water",
-      "mol_formula" : "H2O",
-      "nAtoms"      : 3,               // atoms per solvent MOLECULE (for grouping)
-      "index"       : "64-",           // start at atom 64, take all remaining as solvent
-      "charges": 
-      [
-        { "element": "O", "charge": -0.834 },
-        { "element": "H", "charge":  0.417 },
-        { "element": "H", "charge":  0.417 }
-      ]
-    }
-  ]
-  ```
+### 2. `system_info.json` (`--system-info`)
 
-- **`system`** — the short label used to **name the output files** for that monomer
-  (e.g. `m1-qm.xyz`, `m1.com`). Call them `m1`/`m2`, `mA`/`mB`, or anything you like.
-  If omitted, the code falls back to `monomer1`, `monomer2`, …
-- **`name`** — descriptive name that appears in `.xyz`/`.com` titles and comments (not filenames).
-- **`index`** — 0-based atom index spec selecting that system's atoms from each trajectory frame:
-  - `"0-31"` → atoms 0 through 31 (inclusive)
-  - `"64-"`  → atom 64 through the end (use for the solvent)
-  - `"0-9,20-31"` → multiple ranges (atoms need **not** be contiguous)
-  - With `index`, the trajectory atom order is flexible (cores need not come first).
-  - `index` ranges must not overlap between systems; out-of-range/overlapping indices raise an error.
-- **`nAtoms`** — for a monomer it is the atom count (optional when `index` is given; if both are
-  present they are cross-checked). For the **solvent** it is atoms-per-molecule and is always required.
-- **Legacy mode:** if no monomer has an `index`, atoms are taken sequentially by `nAtoms`
-  (`[monomer1 … monomerN][solvent …]`), exactly as before.
+A **JSON array**: one entry per monomer, followed by **exactly one** solvent entry.
 
----
+```jsonc
+[
+  {
+    "system"      : "m1",            // label used to NAME this system's output files
+    "name"        : "cv",            // descriptive name shown in titles/comments
+    "mol_formula" : "C16H12N3O1",
+    "nAtoms"      : 32,
+    "index"       : "0-31",          // 0-based atom indices for this monomer in the trajectory
+    "charge"      : 1,
+    "spin_mult"   : 1
+  },
+  {
+    "system"      : "m2",
+    "name"        : "cv",
+    "mol_formula" : "C16H12N3O1",
+    "nAtoms"      : 32,
+    "index"       : "32-63",
+    "charge"      : 1,
+    "spin_mult"   : 1
+  },
+  {
+    "system"      : "solvent",
+    "name"        : "water",
+    "mol_formula" : "H2O",
+    "nAtoms"      : 3,               // atoms per solvent MOLECULE (for grouping)
+    "index"       : "64-",           // atom 64 → end is solvent
+    "charges": [
+      { "element": "O", "charge": -0.834 },
+      { "element": "H", "charge":  0.417 },
+      { "element": "H", "charge":  0.417 }
+    ]
+  }
+]
+```
 
-### `Charges`
+| Field | Applies to | Meaning |
+|-------|------------|---------|
+| `system` | monomer | Short label used to **name output files** (`m1-qm.xyz`, `m1.com`). Use `m1`/`mA`/anything. Falls back to `monomer1`, `monomer2`, … if omitted. |
+| `name` | monomer, solvent | Descriptive name shown in `.xyz`/`.com` **titles & comments** (not filenames). |
+| `index` | monomer, solvent | 0-based atom selection from each frame (see below). |
+| `nAtoms` | monomer, solvent | Monomer: atom count (optional when `index` given — cross-checked if both). **Solvent: atoms per molecule, always required.** |
+| `mol_formula` | monomer, solvent | Chemical formula; for the solvent it drives molecule grouping. |
+| `charge`, `spin_mult` | monomer | Charge and spin multiplicity used in the `.com` files. |
+| `charges` | solvent | Per-atom MM point charges (one entry per atom of one solvent molecule). |
 
-- ### (a) Inter‑monomer charges (`--mm-monomer`)
+**The `index` spec** (0-based) controls exactly which trajectory atoms each system owns:
 
-  Plain text with **four** columns (charge x y z) and two header lines (XYZ‑like):
+| Example | Selects |
+|---------|---------|
+| `"0-31"` | atoms 0 through 31 (inclusive) |
+| `"64-"` | atom 64 through the end (handy for solvent) |
+| `"0-9,20-31"` | multiple ranges — atoms need **not** be contiguous |
 
-  ```text
-  <natoms>
-  <comment>
-  -0.123   1.234   0.456   -2.345
-  …
-  ```
+- With `index`, the trajectory atom order is **flexible** — cores need not come first.
+- Ranges **must not overlap** between systems; out-of-range or overlapping indices raise a clear error.
 
-  Provide **N** such files when `--num-monomers N` so every monomer can be embedded
-  in the charges of all other monomers.
+<details>
+<summary><b>Legacy mode (no <code>index</code>)</b></summary>
 
-- ### (b) Explicit MM solvent (`--mm-solvent`)
+If **no** monomer defines `index`, GIQPy falls back to sequential slicing by `nAtoms`,
+assuming the classic layout `[monomer1 … monomerN][solvent …]`. Existing inputs keep working unchanged.
+</details>
 
-  Same format as above but the first column is **charge**, followed by *x y z*.
+### 3. Gaussian keywords (`--gauss-keywords`)
 
+Plain text, one route-section line per blank-stripped line:
 
-## Outputs
-- **`giqpy.py`** (always, per frame; `{term}` is `dimer` for `--num-monomers 2`, else `aggregate`):
-  - `{term}-qm.xyz`, `{system}-qm.xyz` : QM-region geometries (core + QM solvent).
-  - `{term}-mm.xyz`, `{system}-mm.xyz` : MM point charges (`charge x y z`), only when MM is requested.
-    The aggregate MM file holds MM solvent only; monomer MM files also include other-monomer embedding.
-    (`{system}` is the per-monomer label from the JSON `system` key, e.g. `m1`, `m2`.)
-- **`xyz-to-gaussian.py`** (from the XYZ files above):
-  - monomer `.com` files named by the `system` label: `m1.com`, `m2.com`, … (suffix `-qm`/`-mm`/`-qm-mm` reflects solvent).
-  - aggregate/dimer `.com` file.
-  - EETG `.com` for dimers when `--eetg` is specified.
+```text
+#p CAM-B3LYP/6-31G*                 ! Functional/basis set
+# TDA(Nstates=6)                    ! Excited-state calculation
+# Density(Transition=1)             ! S0->S1 transition density
+# NoSymm                            ! No symmetry (dimers)
+```
 
-- Temporary files (`_current_frame_data.xyz`) are deleted after use when processing trajectories.
-- Log files (`giqpy-run.log`, `xyz-to-gaussian.log`) are created in the current working directory.
+> When MM charges are present, GIQPy automatically inserts a `# charge` keyword if you didn't include one.
+
+### 4. Charge files (optional)
+
+<details>
+<summary><b>Formats for <code>--mm-monomer</code> and a file-based <code>--mm-solvent</code></b></summary>
+
+**Inter-monomer charges (`--mm-monomer file1 file2 …`)** — four columns `charge x y z`, no header.
+Provide **N** files when `--num-monomers N`; each monomer is then embedded in the charges of all the others.
+
+```text
+-0.123   1.234   0.456   -2.345
+ 0.417   2.345   1.567    0.890
+…
+```
+
+**Explicit MM solvent (`--mm-solvent path/to/file`)** — same `charge x y z` columns, but **with two XYZ-style header lines** (atom count + comment) that are skipped.
+</details>
 
 ---
 
-## Logging & error handling
+## Output files
 
-GIQPy writes a concise console progress bar and mirrors all
-messages—including stack traces on uncaught exceptions—to `giqpy-run.log`.
-Fatal errors return a non‑zero exit status.
+Everything for a frame lands in that frame's folder (`1/`, `2/`, … for trajectories).
+`{term}` is **`dimer`** when `--num-monomers 2`, otherwise **`aggregate`**; `{system}` is your JSON `system` label.
+
+```text
+./1/
+├── dimer-qm.xyz          # aggregate QM region  (all cores + all QM solvent)
+├── m1-qm.xyz             # monomer QM region    (core + its UNIQUE QM solvent)
+├── m2-qm.xyz
+├── dimer-mm.xyz          # aggregate MM charges (MM solvent only)        ┐ only when
+├── m1-mm.xyz             # monomer MM charges   (embedding + MM solvent) │ MM is
+├── m2-mm.xyz             #                                               ┘ requested
+├── dimer-qm-mm.com       # Gaussian inputs (suffix reflects QM/MM solvent)
+├── m1-qm-mm.com
+└── m2-qm-mm.com
+```
+
+| Producer | File | Contents |
+|----------|------|----------|
+| `giqpy.py` | `{term}-qm.xyz` | Aggregate QM region (cores + all QM solvent). |
+| `giqpy.py` | `{system}-qm.xyz` | One monomer's QM region (core + its unique QM solvent). |
+| `giqpy.py` | `{term}-mm.xyz` | Aggregate MM charges — **MM solvent only**. |
+| `giqpy.py` | `{system}-mm.xyz` | Monomer MM charges — other-monomer embedding **+** MM solvent. |
+| `xyz-to-gaussian.py` | `{system}{suffix}.com` | Per-monomer Gaussian input. |
+| `xyz-to-gaussian.py` | `{term}{suffix}.com` | Aggregate/dimer Gaussian input. |
+| `xyz-to-gaussian.py` | `{term}-eetg{suffix}.com` | EET-analysis dimer input (`--eetg`). |
+
+The `{suffix}` encodes the solvent treatment: `-qm`, `-mm`, `-qm-mm`, or nothing.
+MM `.xyz` files store `charge x y z` (not `element x y z`); their header line says so.
 
 ---
 
-### Acknowledgements
+## Command-line reference
 
-Developed with ♥ by *Sayan Adhikari* and *Claude*
+### `giqpy.py` — trajectory → QM/MM XYZ files
+
+| Flag | Required | Default | Description |
+|------|:--------:|---------|-------------|
+| `--traj` | ✅ | — | Multi-frame trajectory XYZ (use `--num-frames 1` for one frame). |
+| `--num-monomers` | ✅ | — | Number of core monomer units. |
+| `--system-info` | ✅ | — | `system_info.json` (monomer + solvent metadata). |
+| `--num-frames` | — | all | Number of frames to process. |
+| `--qm-radius` | — | `5.0` | QM-solvent shell radius (Å). **Negative disables QM solvent.** |
+| `--mm-monomer` | — | off | `0` = embed other monomers as zero charges; or one charge file per monomer. |
+| `--mm-solvent` | — | off | Flag alone = auto-charge non-QM solvent from JSON; or a path to a charge file. |
+| `--log-file` | — | `giqpy-run.log` | Log file name. |
+
+### `xyz-to-gaussian.py` — XYZ files → Gaussian `.com`
+
+| Flag | Required | Default | Description |
+|------|:--------:|---------|-------------|
+| `--num-monomers` | ✅ | — | Must match the `giqpy.py` run. |
+| `--system-info` | ✅ | — | Same JSON (provides charge / spin / names). |
+| `--gauss-keywords` | ✅ | — | Gaussian route-section keywords file. |
+| `--input-dir` | — | `.` | Folder with the XYZ files, or a parent of numbered frame folders. |
+| `--com-files` | — | `both` | Which inputs: `monomer`, `dimer`, or `both`. |
+| `--eetg` | — | off | Generate **only** the EETG dimer input (requires `--num-monomers 2`). |
+| `--tag` | — | — | Custom tag appended to `.com` filenames (e.g. `m1-qm-mm-TAG.com`). |
+| `--log-file` | — | `xyz-to-gaussian.log` | Log file name. |
+
+---
+
+## Notes & tips
+
+- **Solvent treatments combine freely:** none, QM only, MM only, or QM + MM.
+- **MM solvent auto-detection** (`--mm-solvent` with no path) assigns charges to every
+  non-QM solvent molecule using the `charges` template in the JSON, matching by atom position.
+- **Embedding semantics:** the aggregate `.com` carries MM solvent only; each monomer `.com`
+  additionally carries the other monomers' charges (zero or explicit, per `--mm-monomer`).
+- **Logging:** progress prints to the console; full details (and stack traces on failure) go to
+  the log file. A bad frame in a trajectory is skipped with a warning rather than aborting the run.
+- **Housekeeping:** per-frame scratch files (`current-frame.xyz`) are removed automatically.
+
+---
+
+## Acknowledgements
+
+Developed with ♥ by *Sayan Adhikari* and *Claude*.


### PR DESCRIPTION
Restructure the README for clarity and a professional look:
- Centered hero header with tagline and status badges.
- Table of contents, "Why GIQPy?" feature list, and an IMPORTANT callout highlighting the unique-QM-solvent-per-monomer guarantee.
- Mermaid pipeline diagram + stage table for the two-script workflow.
- Installation, quick start, and input/output sections with field tables, an annotated output tree, and collapsible details for charge-file formats and legacy mode.
- CLI flags presented as tidy reference tables instead of bullet lists.
- Fix stale temp-file name (now current-frame.xyz).