### PR TITLE
Style README diagram: uniform white boxes, dark text

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,17 @@ GIQPy is a two-stage pipeline. Stage 1 is geometry; stage 2 is QM-package format
 
 ```mermaid
 flowchart LR
-    T[Trajectory XYZ]:::in --> G[giqpy.py]
-    J[system_info.json]:::in --> G
-    G --> X["QM-region .xyz<br/>+ MM-charge .xyz<br/>(per frame)"]:::mid
+    T[Trajectory XYZ] --> G[giqpy.py]
+    J[system_info.json] --> G
+    G --> X["QM-region .xyz<br/>+ MM-charge .xyz<br/>(per frame)"]
     X --> H[xyz-to-gaussian.py]
-    K[keywords.txt]:::in --> H
+    K[keywords.txt] --> H
     J --> H
-    H --> C[Gaussian .com files]:::out
-    X -. also usable by .-> TC[TeraChem]:::out
+    H --> C[Gaussian .com files]
+    X -. also usable by .-> TC[TeraChem]
 
-    classDef in fill:#eef,stroke:#88a;
-    classDef mid fill:#efe,stroke:#8a8;
-    classDef out fill:#fee,stroke:#a88;
+    classDef box fill:#ffffff,stroke:#333333,stroke-width:1px,color:#111111;
+    class T,G,J,X,H,K,C,TC box;
 ```
 
 | Stage | Script | In → Out |


### PR DESCRIPTION
## What

Styles the README Mermaid pipeline diagram so every box uses one consistent look:
**opaque white fill, dark text, subtle gray border** — readable on both GitHub
light and dark themes (replacing the previous pastel, low-contrast node classes).

## Why

On GitHub's dark theme the old pastel boxes rendered with washed-out, hard-to-read
text. A single uniform white-card style fixes legibility everywhere.

## Notes
- This is the one commit that landed on `refactor/split-xyz-gaussian` *after*
  PR #4 was merged, so it needs its own PR.
- The zoom/pan controls seen in some preview tools are viewer chrome; GitHub
  renders Mermaid as a static, page-width SVG with no such buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
